### PR TITLE
Change `paddingLineBetweenTags` to `always`

### DIFF
--- a/.changeset/cuddly-hounds-crash.md
+++ b/.changeset/cuddly-hounds-crash.md
@@ -1,0 +1,5 @@
+---
+'@clickbar/eslint-config-vue': minor
+---
+
+Enforce blank lines between sibling elements in the template

--- a/packages/vue/index.js
+++ b/packages/vue/index.js
@@ -106,7 +106,7 @@ module.exports = {
     'vue/padding-line-between-blocks': 'error',
     'vue/padding-line-between-tags': [
       'error',
-      [{ blankLine: 'consistent', prev: '*', next: '*' }],
+      [{ blankLine: 'always', prev: '*', next: '*' }],
     ],
     'vue/prefer-define-options': 'error',
     'vue/prefer-import-from-vue': 'warn',


### PR DESCRIPTION
I like the general idea behind `consistent`, since it allows you to opt out of "letting it breathe" for certain contexts where the separation feels overkill. However, I argue that those cases are a rarity and the code and its hierarchy would look much less cluttered with larger spacing between siblings. It's just that when we use `consistent`, we always forget to properly space our siblings so it's basically equivalent to us using `never`, which is not what we want. Let's get it right 90% of the time by using `always`. 

Also I'm new to this repo, so no idea how version numbers are bumped and updates are pushed here.