### PR TITLE
fix(base): disable unicorn/require-module-specifiers until TS compatible

### DIFF
--- a/.changeset/purple-paths-cough.md
+++ b/.changeset/purple-paths-cough.md
@@ -1,0 +1,5 @@
+---
+'@clickbar/eslint-config-base': patch
+---
+
+Disable unicorn/require-module-specifiers -> incompatible with TypeScript module detection

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -152,6 +152,10 @@ export default function base() {
         // which is not valid TypeScript.
         'unicorn/prefer-string-raw': 'off',
 
+        // This rule is not compatible with TypeScript modules
+        // See https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2710
+        'unicorn/require-module-specifiers': 'off',
+
         // Prevent clashes with prettier formatting
         'unicorn/template-indent': 'off',
         'unicorn/empty-brace-spaces': 'off',


### PR DESCRIPTION
Fixes #238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved TypeScript module detection incompatibility in ESLint configuration by disabling a conflicting rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->